### PR TITLE
Theme on startup

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -57,9 +57,9 @@ export function toggle() {
 }
 
 export function activate() {
-  subscriptions.add(atom.commands.add('atom-workspace', {
-      'auto-dark-mode:toggle': () => this.toggle()
-  }))
+    subscriptions.add(atom.commands.add('atom-workspace', {
+        'auto-dark-mode:toggle': () => this.toggle()
+    }))
 
     setTimeout(() => {
         if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
@@ -68,10 +68,10 @@ export function activate() {
         else this.changeTheme(this.lightTheme());
     }, 50);
 
-  window.matchMedia("(prefers-color-scheme: dark)").addListener(e => {
-    if (e.matches) this.onDark()
-    else this.onLight()
-  });
+    window.matchMedia("(prefers-color-scheme: dark)").addListener(e => {
+        if (e.matches) this.onDark()
+        else this.onLight()
+    });
 }
 
 export function deactivate() {

--- a/lib/main.js
+++ b/lib/main.js
@@ -61,6 +61,13 @@ export function activate() {
       'auto-dark-mode:toggle': () => this.toggle()
   }))
 
+    setTimeout(() => {
+        if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+            this.changeTheme(this.darkTheme());
+        }
+        else this.changeTheme(this.lightTheme());
+    }, 50);
+
   window.matchMedia("(prefers-color-scheme: dark)").addListener(e => {
     if (e.matches) this.onDark()
     else this.onLight()


### PR DESCRIPTION
This PR adds code to detect and change the theme on startup.  The `SetTimeout` function is used because, without it, some UI elements aren't changed.  

Initially used `this.onLight()` and `this.onDark()` but they triggered a notification.

Fixes https://github.com/paysonwallach/auto-dark-mode/issues/9 and https://github.com/paysonwallach/auto-dark-mode/issues/8

Tested on Atom 1.54.0 on Windows 10 20H2 (19042.804) and MacOS Big Sur 11.2.